### PR TITLE
Fix typo and updated write-host to use variables in Remediate.ps1

### DIFF
--- a/Remediate.ps1
+++ b/Remediate.ps1
@@ -37,7 +37,7 @@ Function Manage-Services {
 
 #region Process
 try {
-    Write-Host "Fixing TimeZone service statup type to MANUAL."
+    Write-Host "Fixing $ServiceName service startup type to $Action."
     Manage-Services -ServiceName $ServiceName -Action $Action
     Exit 0
 }


### PR DESCRIPTION
Line 40: Fixed typo and changed to use $ServiceName and $Action to make the script more modular.